### PR TITLE
Compilation Error

### DIFF
--- a/src/com/alanmacdougall/underscore/_.as
+++ b/src/com/alanmacdougall/underscore/_.as
@@ -505,7 +505,7 @@ public var _:* = (function():Function {
 	_.object = function(list:Array, values:Array = null):Object {
 		if (list == null) return {};
 		var result:Object = {};
-		for (var i:int = 0, l:Array = list.length; i < l; i++) {
+		for (var i:int = 0, l:uint = list.length; i < l; i++) {
 		  if (values) {
 			result[list[i]] = values[i];
 		  } else {


### PR DESCRIPTION
Fixed a compilation error in _.object function, which access the list.length, should be uint instead of Array.
