### PR TITLE
Adding map to associative array

### DIFF
--- a/src/com/alanmacdougall/underscore/_.as
+++ b/src/com/alanmacdougall/underscore/_.as
@@ -112,7 +112,7 @@ public var _:* = (function():Function {
 	 * Returns the input items, transformed by the iterator, as an associative array, 
 	 * based on the attribute index
 	 */
-	var mapAssoc:Function = _.mapAssoc = function(obj:*, iterator:Function, context:Object = null):Object {
+	var mapObject:Function = _.mapAssoc = function(obj:*, iterator:Function, context:Object = null):Object {
 		var results:Object = {};
 		if (obj == null) return results;
 		

--- a/src/com/alanmacdougall/underscore/_.as
+++ b/src/com/alanmacdougall/underscore/_.as
@@ -112,7 +112,7 @@ public var _:* = (function():Function {
 	 * Returns the input items, transformed by the iterator, as an associative array, 
 	 * based on the attribute index
 	 */
-	var mapObject:Function = _.mapAssoc = function(obj:*, iterator:Function, context:Object = null):Object {
+	var mapObject:Function = _.mapObject = function(obj:*, iterator:Function, context:Object = null):Object {
 		var results:Object = {};
 		if (obj == null) return results;
 		

--- a/src/com/alanmacdougall/underscore/_.as
+++ b/src/com/alanmacdougall/underscore/_.as
@@ -108,6 +108,21 @@ public var _:* = (function():Function {
 		return results;
 	};
 	
+	/** 
+	 * Returns the input items, transformed by the iterator, as an associative array, 
+	 * based on the attribute index
+	 */
+	var mapAssoc:Function = _.mapAssoc = function(obj:*, iterator:Function, context:Object = null):Object {
+		var results:Object = {};
+		if (obj == null) return results;
+		
+		// TO DO: benchmark native Array.map
+		each(obj, function(value:*, index:*, list:* = null):* {
+			results[index] = (safeCall(iterator, context, value, index, list));
+		});
+		return results;
+	};
+	
 	/**
 	 * Returns the input items, filtered by the iterator, as an Array. Aliased
 	 * as _.select.


### PR DESCRIPTION
New function mapAssoc: Returns the input items, transformed by the iterator, as an associative array, based on the attribute index
